### PR TITLE
Macro wrappers to check list element pointer sizes

### DIFF
--- a/libuproc/include/uproc/list.h
+++ b/libuproc/include/uproc/list.h
@@ -66,7 +66,11 @@ void uproc_list_clear(uproc_list *list);
  *
  * Copies the data of the item at \c index into \c *value.
  */
-int uproc_list_get(const uproc_list *list, long index, void *value);
+int uproc_list_get_safe(const uproc_list *list, long index, void *value,
+                        size_t value_size);
+
+#define uproc_list_get(list, index, value) \
+    uproc_list_get_safe((list), (index), (value), sizeof *(value))
 
 /** Get all items
  *
@@ -88,13 +92,21 @@ size_t uproc_list_get_all(const uproc_list *list, void *buf, size_t sz);
  * Stores a copy of \c *value at position \c index, which must be less than the
  * size of the list.
  */
-int uproc_list_set(uproc_list *list, long index, const void *value);
+int uproc_list_set_safe(uproc_list *list, long index, const void *value,
+                        size_t value_size);
+
+#define uproc_list_set(list, index, value) \
+    uproc_list_set_safe((list), (index), (value), sizeof *(value))
 
 /** Append item to list
  *
  * Stores a copy of \c *value at the end of the list.
  */
-int uproc_list_append(uproc_list *list, const void *value);
+int uproc_list_append_safe(uproc_list *list, const void *value,
+                           size_t value_size);
+
+#define uproc_list_append(list, value) \
+    uproc_list_append_safe((list), (value), sizeof *(value))
 
 /** Append array of items
  *
@@ -110,7 +122,10 @@ int uproc_list_extend(uproc_list *list, const void *values, long n);
 int uproc_list_add(uproc_list *list, const uproc_list *src);
 
 /** Get and remove the last item */
-int uproc_list_pop(uproc_list *list, void *value);
+int uproc_list_pop_safe(uproc_list *list, void *value, size_t value_size);
+
+#define uproc_list_pop(list, value) \
+    uproc_list_pop_safe((list), (value), sizeof *(value))
 
 /** Returns the number of items */
 long uproc_list_size(const uproc_list *list);

--- a/libuproc/include/uproc/list.h
+++ b/libuproc/include/uproc/list.h
@@ -62,20 +62,24 @@ void uproc_list_destroy(uproc_list *list);
 /** Remove all items */
 void uproc_list_clear(uproc_list *list);
 
-/* Get item at index
- *
- * Copies the data of the item at \c index into \c *value.
- */
 int uproc_list_get_safe(const uproc_list *list, long index, void *value,
                         size_t value_size);
 
+/* Get item at index
+ *
+ * Copies the data of the item at \c index into \c *value.
+ * NOTE: \c value WILL BE EVALUATED TWICE.
+ */
 #define uproc_list_get(list, index, value) \
     uproc_list_get_safe((list), (index), (value), sizeof *(value))
 
+size_t uproc_list_get_all_safe(const uproc_list *list, void *buf, size_t sz,
+                               size_t value_size);
 /** Get all items
  *
  * Copies the whole list data, but at most \c sz bytes, into the array pointed
  * to by \c dest.
+ * NOTE: \c buf WILL BE EVALUATED TWICE.
  *
  * \param list  list to copy from
  * \param buf   buffer to copy into
@@ -85,34 +89,43 @@ int uproc_list_get_safe(const uproc_list *list, long index, void *value,
  * the number of copied bytes, or how many bytes would have been
  * copied, if this number exceeds \c sz.
  */
-size_t uproc_list_get_all(const uproc_list *list, void *buf, size_t sz);
+#define uproc_list_get_all(list, buf, sz) \
+    uproc_list_get_all_safe((list), (buf), (sz), sizeof *(buf))
+
+int uproc_list_set_safe(uproc_list *list, long index, const void *value,
+                        size_t value_size);
 
 /** Set item at index
  *
  * Stores a copy of \c *value at position \c index, which must be less than the
  * size of the list.
+ * NOTE: \c value WILL BE EVALUATED TWICE.
  */
-int uproc_list_set_safe(uproc_list *list, long index, const void *value,
-                        size_t value_size);
-
 #define uproc_list_set(list, index, value) \
     uproc_list_set_safe((list), (index), (value), sizeof *(value))
+
+int uproc_list_append_safe(uproc_list *list, const void *value,
+                           size_t value_size);
 
 /** Append item to list
  *
  * Stores a copy of \c *value at the end of the list.
+ * NOTE: \c value WILL BE EVALUATED TWICE.
  */
-int uproc_list_append_safe(uproc_list *list, const void *value,
-                           size_t value_size);
-
 #define uproc_list_append(list, value) \
     uproc_list_append_safe((list), (value), sizeof *(value))
+
+int uproc_list_extend_safe(uproc_list *list, const void *values, long n,
+                           size_t value_size);
 
 /** Append array of items
  *
  * Appends the \c n elements of \c values to the end of the list.
+ *
+ * NOTE: \c values WILL BE EVALUATED TWICE.
  */
-int uproc_list_extend(uproc_list *list, const void *values, long n);
+#define uproc_list_extend(list, values, n) \
+    uproc_list_extend_safe((list), (values), (n), sizeof *(values))
 
 /** Append all elements of another list
  *
@@ -121,9 +134,13 @@ int uproc_list_extend(uproc_list *list, const void *values, long n);
  */
 int uproc_list_add(uproc_list *list, const uproc_list *src);
 
-/** Get and remove the last item */
 int uproc_list_pop_safe(uproc_list *list, void *value, size_t value_size);
 
+/** Get and remove the last item
+ *
+ * NOTE: \c value WILL BE EVALUATED TWICE.
+ *
+ * */
 #define uproc_list_pop(list, value) \
     uproc_list_pop_safe((list), (value), sizeof *(value))
 

--- a/libuproc/list.c
+++ b/libuproc/list.c
@@ -31,8 +31,10 @@
 
 // Undef macros from list.h that invoke the _safe variant.
 #undef uproc_list_get
+#undef uproc_list_get_all
 #undef uproc_list_set
 #undef uproc_list_append
+#undef uproc_list_extend
 #undef uproc_list_pop
 
 #define MIN_CAPACITY 32
@@ -179,6 +181,14 @@ size_t uproc_list_get_all(const uproc_list *list, void *buf, size_t sz)
     return needed;
 }
 
+size_t uproc_list_get_all_safe(const uproc_list *list, void *buf, size_t sz,
+                               size_t value_size) {
+    if (uproc_list_check_value_size(list, value_size)) {
+        return 0;
+    }
+    return uproc_list_get_all(list, buf, sz);
+}
+
 int uproc_list_set(uproc_list *list, long index, const void *value)
 {
     long idx = index;
@@ -235,6 +245,13 @@ int uproc_list_extend(uproc_list *list, const void *values, long n)
            n * list->value_size);
     list->size += n;
     return 0;
+}
+
+int uproc_list_extend_safe(uproc_list *list, const void *values, long n,
+                        size_t value_size)
+{
+    return uproc_list_check_value_size(list, value_size) ||
+           uproc_list_extend(list, values, n);
 }
 
 int uproc_list_add(uproc_list *list, const uproc_list *src)

--- a/libuproc/list.c
+++ b/libuproc/list.c
@@ -182,7 +182,8 @@ size_t uproc_list_get_all(const uproc_list *list, void *buf, size_t sz)
 }
 
 size_t uproc_list_get_all_safe(const uproc_list *list, void *buf, size_t sz,
-                               size_t value_size) {
+                               size_t value_size)
+{
     if (uproc_list_check_value_size(list, value_size)) {
         return 0;
     }
@@ -248,7 +249,7 @@ int uproc_list_extend(uproc_list *list, const void *values, long n)
 }
 
 int uproc_list_extend_safe(uproc_list *list, const void *values, long n,
-                        size_t value_size)
+                           size_t value_size)
 {
     return uproc_list_check_value_size(list, value_size) ||
            uproc_list_extend(list, values, n);

--- a/libuproc/list.c
+++ b/libuproc/list.c
@@ -29,6 +29,12 @@
 #include "uproc/error.h"
 #include "uproc/list.h"
 
+// Undef macros from list.h that invoke the _safe variant.
+#undef uproc_list_get
+#undef uproc_list_set
+#undef uproc_list_append
+#undef uproc_list_pop
+
 #define MIN_CAPACITY 32
 #define MAX_SIZE (LONG_MAX)
 
@@ -125,6 +131,18 @@ void uproc_list_destroy(uproc_list *list)
     free(list);
 }
 
+int uproc_list_check_value_size(const uproc_list *list, size_t value_size)
+{
+    if (value_size && value_size != list->value_size) {
+        return uproc_error_msg(UPROC_EINVAL,
+                               "list value size %lu (possibly) doesn't match "
+                               "size of passed object %lu",
+                               (unsigned long)list->value_size,
+                               (unsigned long)value_size);
+    }
+    return 0;
+}
+
 void uproc_list_clear(uproc_list *list)
 {
     list->size = 0;
@@ -142,6 +160,13 @@ int uproc_list_get(const uproc_list *list, long index, void *value)
     }
     memcpy(value, list->data + idx * list->value_size, list->value_size);
     return 0;
+}
+
+int uproc_list_get_safe(const uproc_list *list, long index, void *value,
+                        size_t value_size)
+{
+    return uproc_list_check_value_size(list, value_size) ||
+           uproc_list_get(list, index, value);
 }
 
 size_t uproc_list_get_all(const uproc_list *list, void *buf, size_t sz)
@@ -168,6 +193,13 @@ int uproc_list_set(uproc_list *list, long index, const void *value)
     return 0;
 }
 
+int uproc_list_set_safe(uproc_list *list, long index, const void *value,
+                        size_t value_size)
+{
+    return uproc_list_check_value_size(list, value_size) ||
+           uproc_list_set(list, index, value);
+}
+
 int uproc_list_append(uproc_list *list, const void *value)
 {
     int res = list_grow(list, 1);
@@ -176,6 +208,13 @@ int uproc_list_append(uproc_list *list, const void *value)
     }
     list->size++;
     return uproc_list_set(list, list->size - 1, value);
+}
+
+int uproc_list_append_safe(uproc_list *list, const void *value,
+                           size_t value_size)
+{
+    return uproc_list_check_value_size(list, value_size) ||
+           uproc_list_append(list, value);
 }
 
 int uproc_list_extend(uproc_list *list, const void *values, long n)
@@ -218,6 +257,12 @@ int uproc_list_pop(uproc_list *list, void *value)
         return 0;
     }
     return list_realloc(list, list->capacity / 2);
+}
+
+int uproc_list_pop_safe(uproc_list *list, void *value, size_t value_size)
+{
+    return uproc_list_check_value_size(list, value_size) ||
+           uproc_list_pop(list, value);
 }
 
 long uproc_list_size(const uproc_list *list)

--- a/libuproc/tests/ck_list.c
+++ b/libuproc/tests/ck_list.c
@@ -167,9 +167,10 @@ END_TEST
 
 START_TEST(test_value_size_check)
 {
-    struct foo {
+    struct foo
+    {
         int x[10];
-    } foo = { { 0 } };
+    } foo = {{0}};
     int bar = 42;
 
     uproc_list *tmp = uproc_list_create(sizeof foo);

--- a/libuproc/tests/ck_list.c
+++ b/libuproc/tests/ck_list.c
@@ -73,7 +73,7 @@ START_TEST(test_list)
     value.x = 114;
     value.c = '!';
     res = uproc_list_get(list, 10006, &value);
-    ck_assert_int_eq(res, -1);
+    ck_assert_int_ne(res, 0);
     ck_assert_int_eq(value.x, 114);
     ck_assert_int_eq(value.c, '!');
 }
@@ -165,6 +165,23 @@ START_TEST(test_map)
 }
 END_TEST
 
+START_TEST(test_value_size_check)
+{
+    struct foo {
+        int x[10];
+    } foo = { { 0 } };
+    int bar = 42;
+
+    uproc_list *tmp = uproc_list_create(sizeof foo);
+    ck_assert_int_eq(uproc_list_append(tmp, &foo), 0);
+    ck_assert_int_ne(uproc_list_append(tmp, &bar), 0);
+
+    ck_assert_int_eq(uproc_list_set(tmp, 0, &foo), 0);
+    ck_assert_int_eq(uproc_list_get(tmp, 0, &foo), 0);
+    ck_assert_int_ne(uproc_list_set(tmp, 0, &bar), 0);
+}
+END_TEST
+
 int main(void)
 {
     Suite *s = suite_create("list");
@@ -175,6 +192,7 @@ int main(void)
     tcase_add_test(tc, test_pop);
     tcase_add_test(tc, test_negative_index);
     tcase_add_test(tc, test_map);
+    tcase_add_test(tc, test_value_size_check);
     tcase_add_checked_fixture(tc, setup, teardown);
     suite_add_tcase(s, tc);
 


### PR DESCRIPTION
To prevent programmer errors, verify that the type of the pointed-to object is of the correct size.
